### PR TITLE
Added support for showing the panel with sliding up gestures

### DIFF
--- a/library/src/main/java/com/mypopsy/widget/SlidingUpPaneLayout.java
+++ b/library/src/main/java/com/mypopsy/widget/SlidingUpPaneLayout.java
@@ -1073,16 +1073,19 @@ public class SlidingUpPaneLayout extends ViewGroup {
 
         @Override
         public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
+
+
             try {
                 float deltaY = e2.getY() - e1.getY();
                 float deltaX = e2.getX() - e1.getX();
 
-                if (Math.abs(deltaX) <= Math.abs(deltaY)) {
-                    if (Math.abs(deltaY) > SLIDE_THRESHOLD) {
-                        if (deltaY <= 0) {
-                            // the user made a sliding up gesture
-                            return onSlideUp();
-                        }
+                if (Math.abs(deltaY) > SLIDE_THRESHOLD) {
+                    if (deltaY > 0) {
+                        // the user made a sliding down gesture
+                        return onSlideDown();
+                    } else {
+                        // the user made a sliding up gesture
+                        return onSlideUp();
                     }
                 }
             } catch (Exception exception) {
@@ -1092,9 +1095,22 @@ public class SlidingUpPaneLayout extends ViewGroup {
             return false;
         }
 
+        private boolean onSlideDown() {
+            if (getState() == State.EXPANDED || getState() == State.ANCHORED) {
+                setState(State.HIDDEN);
+                return true;
+            }
+
+            return false;
+        }
+
         private boolean onSlideUp() {
-            setState(State.EXPANDED);
-            return !isExpanded();
+            if (getState() != State.DRAGGING && getState() != State.EXPANDED) {
+                setState(State.EXPANDED);
+                return true;
+            }
+
+            return false;
         }
     }
 

--- a/library/src/main/java/com/mypopsy/widget/SlidingUpPaneLayout.java
+++ b/library/src/main/java/com/mypopsy/widget/SlidingUpPaneLayout.java
@@ -39,6 +39,7 @@ public class SlidingUpPaneLayout extends ViewGroup {
     private static final String TAG = SlidingUpPaneLayout.class.getSimpleName();
     private static final boolean DEBUG = false;
     private final GestureDetector mGestureDetector;
+    private boolean mIsGestureAllowed;
 
     @Retention(SOURCE)
     @IntDef({IntState.EXPANDED, IntState.ANCHORED, IntState.COLLAPSED, IntState.HIDDEN})
@@ -193,9 +194,14 @@ public class SlidingUpPaneLayout extends ViewGroup {
         setContentScrim(a.getDrawable(R.styleable.SlidingUpPaneLayout_supl_contentScrim));
         setShadowDrawable(a.getDrawable(R.styleable.SlidingUpPaneLayout_supl_shadow));
         setInitialState(a.getInt(R.styleable.SlidingUpPaneLayout_supl_initialState, IntState.COLLAPSED));
+        isGestureAllowed(a.getBoolean(R.styleable.SlidingUpPaneLayout_supl_allowGestures, false));
         mCollapseOnTouchOutside = a.getBoolean(R.styleable.SlidingUpPaneLayout_supl_collapseOnTouchOutside, false);
         mVisibleHeight = a.getDimensionPixelSize(R.styleable.SlidingUpPaneLayout_supl_visibleHeight, 0);
         a.recycle();
+    }
+
+    private void isGestureAllowed(boolean isGestureAllowed) {
+        mIsGestureAllowed = isGestureAllowed;
     }
 
     public float getAnchorPoint() {
@@ -361,7 +367,9 @@ public class SlidingUpPaneLayout extends ViewGroup {
 
         final int action = ev.getAction();
         mDragHelper.processTouchEvent(ev);
-        mGestureDetector.onTouchEvent(ev);
+
+        if (mIsGestureAllowed)
+            mGestureDetector.onTouchEvent(ev);
 
         final float x = ev.getX();
         final float y = ev.getY();

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -19,6 +19,9 @@
             <enum name="collapsed" value="2"/>
             <enum name="hidden" value="3"/>
         </attr>
+
+        <!-- allow gestures-->>
+        <attr name="supl_allowGestures" format="boolean|reference"/>
     </declare-styleable>
 
 </resources>

--- a/sample/src/main/res/layout/activity_demo.xml
+++ b/sample/src/main/res/layout/activity_demo.xml
@@ -9,6 +9,7 @@
     app:supl_anchor="0.5"
     app:supl_contentScrim="#a0000000"
     app:supl_shadow="@drawable/shadow"
+    app:supl_allowGestures="true"
     app:supl_initialState="hidden"
     app:supl_visibleHeight="?attr/actionBarSize"
     app:supl_collapseOnTouchOutside="true"


### PR DESCRIPTION
The motivation of this pull request is to enable a feature for letting the user slide up the panel outside the anchored view, performing that action in the main content. The benefits from an UX point of view are huge, since after discover the draggable feature the user could naturally try to show the panel with a slide up gesture.